### PR TITLE
Fix bug when there are no species in group 

### DIFF
--- a/app/models/species.rb
+++ b/app/models/species.rb
@@ -15,6 +15,10 @@ class Species
 	end
 
 	def self.find_names(taxIDList)
+    if taxIDList.empty?
+      return []
+    end
+
 		res = JSON.parse(get('?speciesIn=' + taxIDList.join(',')).body)
 		return res
 	end


### PR DESCRIPTION
This bug happened only when the logged user is part of that group (not only for moderators).

## 🛠️ Changes
- Add validation in find species names function before making api requests 

## 📝 Associated issues
#448 

## 🤔 Considerations
In dev there are two groups without species: 55 and 24
