### PR TITLE
Hotfix/2.11.2

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,4 +1,4 @@
-# BioModelos v2.11.1
+# BioModelos v2.11.2
 
 [BioModelos](http://biomodelos.humboldt.org.co) is a web app that facilitates the generation, validation and consultation of hypothesis of species distribution for the continental biodiversity of Colombia. As such, it provides tools to (1) improve existing species distribution models (SDMs) by integrating expert's opinion, (2) generate expert maps and (3) publish SDMs. Our objective is to provide freely and openly access to the most up to date information on species distributions, validated by a large network of researchers, to support national environmental decision making processes and research.
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -34,3 +34,4 @@
 //= require clipboard/dist/clipboard.min.js
 //= require_tree ./angular
 //= require_tree ./controllers
+//= require turbolinks


### PR DESCRIPTION
## 🛠️ Changes
- Add turbolinks application.js to solve bug with Google Analytics 

## 📝 Associated issues
#472 

## 🤔 Considerations
Apparently, Turbolinks were not working properly due to a mistake in the gem setup. This issue has been fixed in this PR, but it's not easy to test in a non-production environment beacause of the configuration of Google Analytics account. I suggest verifying that the `trackGoogleAnalytics` method, included in the `analytics.js file`, is executed properly.