### PR TITLE
Hotfix/2.11.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,6 @@ gem 'coffee-rails', '~> 5.0.0'
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
-# Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-gem 'turbolinks', '~> 5.2.0'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,9 +240,6 @@ GEM
     stringio (3.0.2)
     thor (1.2.1)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     warden (1.2.9)
@@ -285,7 +282,6 @@ DEPENDENCIES
   sdoc (~> 2.0, >= 2.0.3)
   simple_form (>= 3.5.0)
   spring (~> 2.0.2)
-  turbolinks (~> 5.2.0)
   web-console (~> 4.0)
 
 BUNDLED WITH

--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -1,12 +1,7 @@
-window.dataLayer = window.dataLayer || []
-function gtag() { dataLayer.push(arguments) }
-
-gtag('js', new Date())
-
-const trackGoogleAnalytics = (event) => {
-  gtag('config', 'G-WD07J9FEXQ', {
-    'cookie_flags': 'max-age=7200;secure;samesite=none'
-  })
+window.dataLayer = window.dataLayer || [];
+function gtag() {
+  dataLayer.push(arguments);
 }
+gtag("js", new Date());
 
-document.addEventListener('turbolinks:load', trackGoogleAnalytics)
+gtag("config", "G-WD07J9FEXQ");


### PR DESCRIPTION
## 🛠️ Changes
- Drop turbolinks gem and logic associated to Google Analytics

## 📝 Associated issues
#472 
